### PR TITLE
Added an NFC tag that toggles downstairs bedtime

### DIFF
--- a/automation/downstairs_bedtime.yaml
+++ b/automation/downstairs_bedtime.yaml
@@ -1,0 +1,9 @@
+alias: Tag Downstairs Bedtime tag is scanned
+description: ''
+trigger:
+- platform: tag
+  tag_id: 7a346207-331a-42ea-8834-ffccf4d1636a
+condition: []
+action:
+- service: script.downstairs_bedtime
+mode: single

--- a/scripts/downstairs_bedtime.yaml
+++ b/scripts/downstairs_bedtime.yaml
@@ -1,0 +1,18 @@
+#
+# Downstairs bedtime.
+# - Turns off all lights
+# - Locks all doors.
+#
+
+alias: Downstairs Bedtime
+sequence:
+  - service: light.turn_off
+    entity_id:
+      - group.interior_lights
+  - service: media_player.turn_off
+    entity_id: media_player.roku_streaming_stick
+  - service: lock.lock
+    entity_id:  group.all_house_locks
+  - service: switch.turn_off
+    entity_id: switch.unti1_livingroom_socket
+mode: single


### PR DESCRIPTION
Creates a new script that sets the mode for downstairs at night time. Including locking the doors and turning off the lights.
If someone is not home, it will not turn off the outside lights or hallway lights.