### PR TITLE
Create a random media selection tool

### DIFF
--- a/packages/emby.yaml
+++ b/packages/emby.yaml
@@ -15,7 +15,6 @@
 # - Check if the Roku is on, and Emby App is activated.
 # - When an NFC Tag is scanned, select a random episode and play it.
 #
-# sudo apt  install jq
 
 # This is a hack, I wanted to use the base URL for the Rest commands, but 
 # secrets can't be used as variables. If this was a more important

--- a/packages/emby.yaml
+++ b/packages/emby.yaml
@@ -95,17 +95,13 @@ automation:
           turn_on_emby: script.emby_turn_on_livingroom
           open_emby: script.emby_open_livingroom
           media_player: media_player.roku_streaming_stick_2
-  # condition:
-  #   # Test that we support this device and tag
-  #   - "{{ trigger.event.data.tag_id in tags }}"
-  #   - "{{ trigger.event.data.device_id in media_players }}"
     action:
     # Make sure Emby is open, and if it isn't, start it
     - service_template: >
         {% if (is_state( tags[trigger.event.data.tag_id].media_player , "off")) %}
           {{ tags[trigger.event.data.tag_id].turn_on_emby }}
         {% else %}
-          {{ tags[trigger.event.data.tag_id].emby_open_livingroom }}
+          {{ tags[trigger.event.data.tag_id].open_emby }}
         {% endif %}
     - wait_template: "{{ is_state_attr(tags[trigger.event.data.tag_id].media_player, 'source', 'Emby') }}"
     - delay: 5 #this is annoying, need to be more elegant here.

--- a/packages/emby.yaml
+++ b/packages/emby.yaml
@@ -1,0 +1,17 @@
+#
+# Emby
+#
+# The purpose of this package is to allow a random TV show to start
+# after an NFC tag is scanned.
+# 
+# This package has largely been inspired by:
+# - https://community.home-assistant.io/t/thought-id-share-my-nfc-tag-emby-media-player-setup/282127
+# - How to get a dynamic input_select: https://community.home-assistant.io/t/fill-input-select/63865/43
+# - 
+#
+# - The Room detemines which Emby instance is enabled.
+# - A list of shows to randomly tag
+# - API access to Emby, needs to be added to secrets.
+# - Check if the Roku is on, and Emby App is activated.
+#
+#

--- a/packages/emby.yaml
+++ b/packages/emby.yaml
@@ -13,5 +13,23 @@
 # - A list of shows to randomly tag
 # - API access to Emby, needs to be added to secrets.
 # - Check if the Roku is on, and Emby App is activated.
+# - When an NFC Tag is scanned, select a random episode and play it.
 #
-#
+
+# This is a hack, I wanted to use the base URL for the Rest commands, but 
+# secrets can't be used as variables. If this was a more important
+# automation, I would conver this to a component.
+input_text:
+  emby_base_url:
+    initial: !secret emby_base_url
+
+sensor:
+  # Fetch all the episodes from the query, and then find a random episode.
+  - platform: rest
+    name: "Emby - Random Always Sunny Episode"
+    resource_template: "{{ states('input_text.emby_base_url') + '/emby/Shows/21775/Episodes' }}"
+    scan_interval: 4
+    value_template: '{{ value_json.Items[range(0,((value_json.TotalRecordCount | int) -1 ))|random].Id}} '
+    headers:
+      X-Emby-Token: !secret emby_key
+      Content-Type: application/json

--- a/packages/emby.yaml
+++ b/packages/emby.yaml
@@ -66,30 +66,50 @@ rest_command:
       Content-Type: 'application/json'
 
 script:
-  # If emby is not running, configure the Roku Stick to open the Emby App.
-  - alias: Turn on Emby
+  emby_turn_on_livingroom:
     sequence:
     - type: turn_on
       device_id: 0b3641ef9902529c6166b328fbdcfbe7
-      entity_id: remote.roku_streaming_stick
+      entity_id: media_player.roku_streaming_stick_2
       domain: remote
+    mode: single
+
+  emby_open_livingroom:
+    sequence:
     - service: media_player.select_source
       data:
         source: Emby
       target:
-        device_id: 0b3641ef9902529c6166b328fbdcfbe7
+        entity_id: media_player.roku_streaming_stick_2
     mode: single
 
 automation:
   - alias: Emby - NFC Tag Scanned
+    mode: single
     trigger:
-    - platform: tag
-      tag_id: 488f0218-00c6-42a1-8e0e-c40cb540a160
-    # variables:
-    #   tags:
-    #     488f0218-00c6-42a1-8e0e-c40cb540a160:
-    #       session: "{{ stats('sensor.emby_session_upstairs_living_room') }}"
+      - platform: tag
+        tag_id:  6dca970e-7431-4082-be30-39768671197f 
+    variables:
+      tags:
+         6dca970e-7431-4082-be30-39768671197f :
+          tv: Upstairs TV
+          turn_on_emby: script.emby_turn_on_livingroom
+          open_emby: script.emby_open_livingroom
+          media_player: media_player.roku_streaming_stick_2
+  # condition:
+  #   # Test that we support this device and tag
+  #   - "{{ trigger.event.data.tag_id in tags }}"
+  #   - "{{ trigger.event.data.device_id in media_players }}"
     action:
+    # Make sure Emby is open, and if it isn't, start it
+    - service_template: >
+        {% if (is_state( tags[trigger.event.data.tag_id].media_player , "off")) %}
+          {{ tags[trigger.event.data.tag_id].turn_on_emby }}
+        {% else %}
+          {{ tags[trigger.event.data.tag_id].emby_open_livingroom }}
+        {% endif %}
+    - wait_template: "{{ is_state_attr(tags[trigger.event.data.tag_id].media_player, 'source', 'Emby') }}"
+    - delay: 5 #this is annoying, need to be more elegant here.
     - service: rest_command.emby_start_show
       data_template:
         show: sensor.emby_random_always_sunny_episode

--- a/packages/emby.yaml
+++ b/packages/emby.yaml
@@ -48,25 +48,49 @@ rest:
     Content-Type: application/json
   sensor:
     - name: Emby - Session Upstairs Living Room
-      json_attributes:
-        - LastActivityDate
-        - DeviceId
       value_template: >
          {% set items = value_json | selectattr('DeviceName','eq', 'Roku Streaming Stick') | list | first %}
          {{ items['Id'] }} 
     - name: Emby - Session Downstairs Living Room
-      json_attributes:
-        - LastActivityDate
-        - DeviceId
       value_template: >
          {% set items = value_json | selectattr('DeviceName','eq', 'Downstairs Livingroom') | list | first %}
          {{ items['Id'] }} 
 
 rest_command:
   emby_start_show:
-    url: "{{ states('input_text.emby_base_url') }}/emby/Sessions/{{ session }}/Playing?ItemIds={{ show }}&PlayCommand=PlayNow"
+    url: "{{ states('input_text.emby_base_url') }}/emby/Sessions/{{ states(session) }}/Playing?ItemIds={{ states(show) }}&PlayCommand=PlayNow"
     method: POST
     headers:
       accept: '*/*'
       X-Emby-Token: !secret emby_key
       Content-Type: 'application/json'
+
+script:
+  # If emby is not running, configure the Roku Stick to open the Emby App.
+  - alias: Turn on Emby
+    sequence:
+    - type: turn_on
+      device_id: 0b3641ef9902529c6166b328fbdcfbe7
+      entity_id: remote.roku_streaming_stick
+      domain: remote
+    - service: media_player.select_source
+      data:
+        source: Emby
+      target:
+        device_id: 0b3641ef9902529c6166b328fbdcfbe7
+    mode: single
+
+automation:
+  - alias: Emby - NFC Tag Scanned
+    trigger:
+    - platform: tag
+      tag_id: 488f0218-00c6-42a1-8e0e-c40cb540a160
+    # variables:
+    #   tags:
+    #     488f0218-00c6-42a1-8e0e-c40cb540a160:
+    #       session: "{{ stats('sensor.emby_session_upstairs_living_room') }}"
+    action:
+    - service: rest_command.emby_start_show
+      data_template:
+        show: sensor.emby_random_always_sunny_episode
+        session: sensor.emby_session_upstairs_living_room

--- a/packages/emby.yaml
+++ b/packages/emby.yaml
@@ -61,3 +61,12 @@ rest:
       value_template: >
          {% set items = value_json | selectattr('DeviceName','eq', 'Downstairs Livingroom') | list | first %}
          {{ items['Id'] }} 
+
+rest_command:
+  emby_start_show:
+    url: "{{ states('input_text.emby_base_url') }}/emby/Sessions/{{ session }}/Playing?ItemIds={{ show }}&PlayCommand=PlayNow"
+    method: POST
+    headers:
+      accept: '*/*'
+      X-Emby-Token: !secret emby_key
+      Content-Type: 'application/json'

--- a/packages/emby.yaml
+++ b/packages/emby.yaml
@@ -7,7 +7,7 @@
 # This package has largely been inspired by:
 # - https://community.home-assistant.io/t/thought-id-share-my-nfc-tag-emby-media-player-setup/282127
 # - How to get a dynamic input_select: https://community.home-assistant.io/t/fill-input-select/63865/43
-# - 
+# - https://community.home-assistant.io/t/how-to-process-large-json-over-255/67475
 #
 # - The Room detemines which Emby instance is enabled.
 # - A list of shows to randomly tag
@@ -15,6 +15,7 @@
 # - Check if the Roku is on, and Emby App is activated.
 # - When an NFC Tag is scanned, select a random episode and play it.
 #
+# sudo apt  install jq
 
 # This is a hack, I wanted to use the base URL for the Rest commands, but 
 # secrets can't be used as variables. If this was a more important
@@ -22,6 +23,11 @@
 input_text:
   emby_base_url:
     initial: !secret emby_base_url
+
+media_player:
+  - platform: emby
+    host: !secret emby_host
+    api_key: !secret emby_key
 
 sensor:
   # Fetch all the episodes from the query, and then find a random episode.
@@ -33,3 +39,25 @@ sensor:
     headers:
       X-Emby-Token: !secret emby_key
       Content-Type: application/json
+
+rest:
+  resource_template: "{{ states('input_text.emby_base_url') + '/emby/Sessions' }}"
+  scan_interval: 60
+  headers:
+    X-Emby-Token: !secret emby_key
+    Content-Type: application/json
+  sensor:
+    - name: Emby - Session Upstairs Living Room
+      json_attributes:
+        - LastActivityDate
+        - DeviceId
+      value_template: >
+         {% set items = value_json | selectattr('DeviceName','eq', 'Roku Streaming Stick') | list | first %}
+         {{ items['Id'] }} 
+    - name: Emby - Session Downstairs Living Room
+      json_attributes:
+        - LastActivityDate
+        - DeviceId
+      value_template: >
+         {% set items = value_json | selectattr('DeviceName','eq', 'Downstairs Livingroom') | list | first %}
+         {{ items['Id'] }} 


### PR DESCRIPTION
This PR creates a series of sensors, scripts and automations that allow for random selection of a given TV show on Emby. When scanned, The appropriate Roku device is turned on, a show is selected at random and will start playing.