### PR TITLE
Zwave upgrade

### DIFF
--- a/automation/lights/lights_unit1_bedroom.yaml
+++ b/automation/lights/lights_unit1_bedroom.yaml
@@ -4,7 +4,7 @@ use_blueprint:
   path: freakshock88/motion_illuminance_activated_entity.yaml
   input:
     motion_sensor: binary_sensor.unit_1_bedroom_motion
-    target_entity: light.unit1_bedroom_lights
+    target_entity: light.light_bedroom
     no_motion_wait: input_number.unit1_bedroom_lights_off_duration
     time_limit_after: input_datetime.unit1_bedroom_lights_on_start
     time_limit_before: input_datetime.unit1_bedroom_lights_on_stop

--- a/automation/lights/lights_unit1_frontroom.yaml
+++ b/automation/lights/lights_unit1_frontroom.yaml
@@ -4,5 +4,5 @@ use_blueprint:
   path: freakshock88/motion_illuminance_activated_entity.yaml
   input:
     motion_sensor: binary_sensor.unit_1_frontroom_motion
-    target_entity: light.unit1_light_frontroom_ceiling_dimmer
+    target_entity: light.light_frontroom_ceiling
     no_motion_wait: input_number.unit1_frontroom_lights_off_duration

--- a/automation/lights/lights_unit2_livingroom.yaml
+++ b/automation/lights/lights_unit2_livingroom.yaml
@@ -8,3 +8,5 @@ use_blueprint:
     time_limit_before: input_datetime.unit2_livingroom_lights_on_stop
     no_motion_wait: input_number.unit1_frontroom_lights_off_duration
     turn_off_blocker_entity: binary_sensor.first_floor_occupancy
+
+# sensor.unit1_bathroom_illuminance

--- a/automation/lights_on_bedroom2.yaml
+++ b/automation/lights_on_bedroom2.yaml
@@ -1,0 +1,14 @@
+alias: lights_on_bedroom2
+id: '1601820768590'
+description: Turns on the loft light when Person3 is home and it's dark
+trigger:
+- at: '21:10'
+  platform: time
+condition:
+- condition: state
+  entity_id: person.jenn
+  state: home
+action:
+- service: light.turn_on
+  entity_id: light.loft_evening_lights
+mode: single

--- a/automation/person1_bedtime.yaml
+++ b/automation/person1_bedtime.yaml
@@ -1,0 +1,22 @@
+alias: Bedtime
+id: 'bedtime'
+trigger:
+  - platform: state
+    entity_id: input_boolean.bedtime
+    to: 'on'
+    for:
+      hours: 0
+      minutes: 5
+      seconds: 0
+action:
+  - service: light.turn_off
+    entity_id:
+      - group.interior_lights
+  - service: media_player.turn_off
+    entity_id: media_player.roku_streaming_stick
+  - service: lock.lock
+    entity_id:  group.all_house_locks
+  - service: switch.turn_off
+    entity_id: switch.unti1_livingroom_socket
+  - service: homeassistant.turn_off
+    entity_id: input_boolean.bedtime

--- a/blueprints/automation/homeassistant/motion_light.yaml
+++ b/blueprints/automation/homeassistant/motion_light.yaml
@@ -1,0 +1,50 @@
+blueprint:
+  name: Motion-activated Light
+  description: Turn on a light when motion is detected.
+  domain: automation
+  source_url: https://github.com/home-assistant/core/blob/dev/homeassistant/components/automation/blueprints/motion_light.yaml
+  input:
+    motion_entity:
+      name: Motion Sensor
+      selector:
+        entity:
+          domain: binary_sensor
+          device_class: motion
+    light_target:
+      name: Light
+      selector:
+        target:
+          entity:
+            domain: light
+    no_motion_wait:
+      name: Wait time
+      description: Time to leave the light on after last motion is detected.
+      default: 120
+      selector:
+        number:
+          min: 0
+          max: 3600
+          unit_of_measurement: seconds
+
+# If motion is detected within the delay,
+# we restart the script.
+mode: restart
+max_exceeded: silent
+
+trigger:
+  platform: state
+  entity_id: !input motion_entity
+  from: "off"
+  to: "on"
+
+action:
+  - service: light.turn_on
+    target: !input light_target
+  - wait_for_trigger:
+      platform: state
+      entity_id: !input motion_entity
+      from: "on"
+      to: "off"
+  - delay: !input no_motion_wait
+  - service: light.turn_off
+    target: !input light_target

--- a/blueprints/automation/homeassistant/notify_leaving_zone.yaml
+++ b/blueprints/automation/homeassistant/notify_leaving_zone.yaml
@@ -1,0 +1,43 @@
+blueprint:
+  name: Zone Notification
+  description: Send a notification to a device when a person leaves a specific zone.
+  domain: automation
+  source_url: https://github.com/home-assistant/core/blob/dev/homeassistant/components/automation/blueprints/notify_leaving_zone.yaml
+  input:
+    person_entity:
+      name: Person
+      selector:
+        entity:
+          domain: person
+    zone_entity:
+      name: Zone
+      selector:
+        entity:
+          domain: zone
+    notify_device:
+      name: Device to notify
+      description: Device needs to run the official Home Assistant app to receive notifications.
+      selector:
+        device:
+          integration: mobile_app
+
+trigger:
+  platform: state
+  entity_id: !input person_entity
+
+variables:
+  zone_entity: !input zone_entity
+  # This is the state of the person when it's in this zone.
+  zone_state: "{{ states[zone_entity].name }}"
+  person_entity: !input person_entity
+  person_name: "{{ states[person_entity].name }}"
+
+condition:
+  condition: template
+  value_template: "{{ trigger.from_state.state == zone_state and trigger.to_state.state != zone_state }}"
+
+action:
+  domain: mobile_app
+  type: notify
+  device_id: !input notify_device
+  message: "{{ person_name }} has left {{ zone_state }}"

--- a/blueprints/automation/philk/zen34-blueprint.yaml
+++ b/blueprints/automation/philk/zen34-blueprint.yaml
@@ -1,0 +1,143 @@
+blueprint:
+  name: Zooz ZEN34
+  description: Zooz ZEN34 Switch using the ZWave-JS integration.
+  domain: automation
+  input:
+    zwave_device:
+      name: Zooz ZEN34
+      description: List of available Zooz ZEN34 switch.
+      selector:
+        device:
+          integration: zwave_js
+          manufacturer: Zooz
+          model: ZEN34
+    KeyReleased_Up:
+      name: Up Released
+      description: Action to run, when the button is released.
+      default: []
+      selector:
+        action: {}
+    KeyReleased_Down:
+      name: Down Released
+      description: Action to run, when the button is released.
+      default: []
+      selector:
+        action: {}
+    KeyHeld_Up:
+      name: Up Held
+      description: Action to run, when the button is held.
+      default: []
+      selector:
+        action: {}
+    KeyHeld_Down:
+      name: Down Held
+      description: Action to run, when the button is held.
+      default: []
+      selector:
+        action: {}
+    KeyPressed_Up:
+      name: Up press 1x
+      description: Action to run, when the button is pressed one time.
+      default: []
+      selector:
+        action: {}
+    KeyPressed_Down:
+      name: Down press 1x
+      description: Action to run, when the button is pressed one time.
+      default: []
+      selector:
+        action: {}
+    KeyPressed2x_Up:
+      name: Up press 2x
+      description: Action to run, when the button is pressed two time.
+      default: []
+      selector:
+        action: {}
+    KeyPressed2x_Down:
+      name: Down press 2x
+      description: Action to run, when the button is pressed two time.
+      default: []
+      selector:
+        action: {}
+    KeyPressed3x_Up:
+      name: Up press 3x
+      description: Action to run, when the button is pressed three time.
+      default: []
+      selector:
+        action: {}
+    KeyPressed3x_Down:
+      name: Down press 3x
+      description: Action to run, when the button is pressed three time.
+      default: []
+      selector:
+        action: {}
+    KeyPressed4x_Up:
+      name: Up press 4x
+      description: Action to run, when the button is pressed four time.
+      default: []
+      selector:
+        action: {}
+    KeyPressed4x_Down:
+      name: Down press 4x
+      description: Action to run, when the button is pressed four time.
+      default: []
+      selector:
+        action: {}
+    KeyPressed5x_Up:
+      name: Up press 5x
+      description: Action to run, when the button is pressed five time.
+      default: []
+      selector:
+        action: {}
+    KeyPressed5x_Down:
+      name: Down press 5x
+      description: Action to run, when the button is pressed five time.
+      default: []
+      selector:
+        action: {}
+  source_url: https://gist.github.com/philk/5b7c39afcd64d354f04b94fb0217abe1
+mode: single
+max_exceeded: silent
+variables:
+  device_id: !input 'zwave_device'
+trigger:
+- platform: event
+  event_type: zwave_js_event
+condition: '{{ trigger.event.data.device_id == device_id }}'
+action:
+- variables:
+    button_id: '{{ trigger.event.data.property_key_name }}'
+    press_count: '{{ trigger.event.data.value }}'
+- service: logbook.log
+  data:
+    name: Button Id
+    message: '{{ button_id }}'
+- service: logbook.log
+  data:
+    name: Press Count
+    message: '{{ press_count }}'
+- service: logbook.log
+  data:
+    name: Device
+    message: '{{ zwave_device }}'
+- choose:
+  - conditions: '{{ button_id == "002" and press_count == "KeyPressed" }}'
+    sequence: !input 'KeyPressed_Down'
+  - conditions: '{{ button_id == "001" and press_count == "KeyPressed" }}'
+    sequence: !input 'KeyPressed_Up'
+  - conditions: '{{ button_id == "002" and press_count == "KeyPressed2x" }}'
+    sequence: !input 'KeyPressed2x_Down'
+  - conditions: '{{ button_id == "001" and press_count == "KeyPressed2x" }}'
+    sequence: !input 'KeyPressed2x_Up'
+  - conditions: '{{ button_id == "002" and press_count == "KeyPressed3x" }}'
+    sequence: !input 'KeyPressed3x_Down'
+  - conditions: '{{ button_id == "001" and press_count == "KeyPressed3x" }}'
+    sequence: !input 'KeyPressed3x_Up'
+  - conditions: '{{ button_id == "002" and press_count == "KeyPressed4x" }}'
+    sequence: !input 'KeyPressed4x_Down'
+  - conditions: '{{ button_id == "001" and press_count == "KeyPressed4x" }}'
+    sequence: !input 'KeyPressed4x_Up'
+  - conditions: '{{ button_id == "002" and press_count == "KeyPressed5x" }}'
+    sequence: !input 'KeyPressed5x_Down'
+  - conditions: '{{ button_id == "001" and press_count == "KeyPressed5x" }}'
+    sequence: !input 'KeyPressed5x_Up'

--- a/blueprints/automation/sbyx/low-battery-level-detection-notification-for-all-battery-sensors.yaml
+++ b/blueprints/automation/sbyx/low-battery-level-detection-notification-for-all-battery-sensors.yaml
@@ -1,0 +1,74 @@
+blueprint:
+  name: Low battery level detection & notification for all battery sensors
+  description: Regularly test all sensors with 'battery' device-class for crossing
+    a certain battery level threshold and if so execute an action.
+  domain: automation
+  input:
+    threshold:
+      name: Battery warning level threshold
+      description: Battery sensors below threshold are assumed to be low-battery (as
+        well as binary battery sensors with value 'on').
+      default: 20
+      selector:
+        number:
+          min: 5.0
+          max: 100.0
+          unit_of_measurement: '%'
+          mode: slider
+          step: 5.0
+    time:
+      name: Time to test on
+      description: Test is run at configured time
+      default: '10:00:00'
+      selector:
+        time: {}
+    day:
+      name: Weekday to test on
+      description: 'Test is run at configured time either everyday (0) or on a given
+        weekday (1: Monday ... 7: Sunday)'
+      default: 0
+      selector:
+        number:
+          min: 0.0
+          max: 7.0
+          mode: slider
+          step: 1.0
+    exclude:
+      name: Excluded Sensors
+      description: Battery sensors (e.g. smartphone) to exclude from detection. Only
+        entities are supported, devices must be expanded!
+      default:
+        entity_id: []
+      selector:
+        target:
+          entity:
+            device_class: battery
+    actions:
+      name: Actions
+      description: Notifications or similar to be run. {{sensors}} is replaced with
+        the names of sensors being low on battery.
+      selector:
+        action: {}
+  source_url: https://gist.github.com/sbyx/1f6f434f0903b872b84c4302637d0890
+variables:
+  day: !input 'day'
+  threshold: !input 'threshold'
+  exclude: !input 'exclude'
+  sensors: "{% set result = namespace(sensors=[]) %} {% for state in states.sensor\
+    \ | selectattr('attributes.device_class', '==', 'battery') %}\n  {% if 0 <= state.state\
+    \ | int(-1) < threshold | int and not state.entity_id in exclude.entity_id %}\n\
+    \    {% set result.sensors = result.sensors + [state.name ~ ' (' ~ state.state\
+    \ ~ ' %)'] %}\n  {% endif %}\n{% endfor %} {% for state in states.binary_sensor\
+    \ | selectattr('attributes.device_class', '==', 'battery') | selectattr('state',\
+    \ '==', 'on') %}\n  {% if not state.entity_id in exclude.entity_id %}\n    {%\
+    \ set result.sensors = result.sensors + [state.name] %}\n  {% endif %}\n{% endfor\
+    \ %} {{result.sensors|join(', ')}}"
+trigger:
+- platform: time
+  at: !input 'time'
+condition:
+- '{{ sensors != '''' and (day | int == 0 or day | int == now().isoweekday()) }}'
+action:
+- choose: []
+  default: !input 'actions'
+mode: single

--- a/packages/lights.yaml
+++ b/packages/lights.yaml
@@ -8,25 +8,24 @@ group:
   interior_lights:
       - light.light_switch # light.kitchen_ceiling_light is what this should be, but I can't get it to name forcibly.
       - light.light_livingroom
-      - light.light_frontroom_ceiling
+      - light.livingroom_ceiling
       - light.porch_light
       - light.kitchen_pendants
       - light.kitchen_cabinets
       - light.kitchen_ceiling_light
       - light.unit1_hallway_lights
-      - light.unit1_light_frontroom_ceiling_dimmer
 
   downstairs_lights: &downstairs_lights
     - light.unit1_light_bedroom_dimmer
     - light.light_switch # light.kitchen_ceiling_light is what this should be, but I can't get it to name forcibly.
     - light.unit1_light_livingroom_dimmer
-    - light.light_frontroom_ceiling_dimmer
+    - light.livingroom_ceiling
     - light.porch_light
     - light.kitchen_pendants
     - light.kitchen_cabinets
     - light.kitchen_ceiling_light
     - light.unit1_hallway_lights
-    - light.unit1_light_frontroom_ceiling_dimmer
+    - light.livingroom_ceiling
     - light.person1_nightlight
     - light.person2_nightlight
 
@@ -77,10 +76,9 @@ light:
       - light.unit1_kitchen_pendants
       - light.unit1_light_bedroom_dimmer
       - light.unit1_hallway_lights
-      - light.unit1_light_frontroom_ceiling_dimmer
+      - light.livingroom_ceiling
       - light.light_switch # light.kitchen_ceiling_light is what this should be, but I can't get it to name forcibly.
       - light.unit1_light_livingroom_dimmer
-      - light.light_frontroom_ceiling_dimmer
       - light.porch_light
       - switch.kitchen_pendants
       - light.kitchen_cabinets
@@ -119,12 +117,11 @@ light:
       - light.unit1_light_bedroom_dimmer
       - light.light_switch # light.kitchen_ceiling_light is what this should be, but I can't get it to name forcibly.
       - light.unit1_light_livingroom_dimmer
-      - light.light_frontroom_ceiling_dimmer
       - light.porch_light
       - light.kitchen_cabinets
       - light.kitchen_ceiling_light
       - light.unit1_hallway_lights
-      - light.unit1_light_frontroom_ceiling_dimmer
+      - light.livingroom_ceiling
       - light.person1_nightlight
       - light.person2_nightlight
 
@@ -186,7 +183,7 @@ light:
 
   - platform: switch
     name: Unit1 Hallway Lights
-    entity_id: switch.kitchen_hallway_lights
+    entity_id: switch.z_wave_plus_700_series_on_off_switch #switch.kitchen_hallway_lights
   
   - platform: switch
     name: Mudroom Ceiling Light

--- a/packages/lights.yaml
+++ b/packages/lights.yaml
@@ -80,7 +80,6 @@ light:
       - light.light_switch # light.kitchen_ceiling_light is what this should be, but I can't get it to name forcibly.
       - light.unit1_light_livingroom_dimmer
       - light.porch_light
-      - switch.kitchen_pendants
       - light.kitchen_cabinets
       - light.kitchen_ceiling_light
 
@@ -171,15 +170,15 @@ light:
   
   - platform: switch
     name: Person2 Nightlight
-    entity_id: switch.unit1_bedroom_switches_switch_1
+    entity_id: switch.bedroom_switches_2 # switch.unit1_bedroom_switches_switch_1
 
   - platform: switch    
     name: Person1 Nightlight
-    entity_id: switch.unit1_bedroom_switches_switch_2
+    entity_id: switch.bedroom_switches_3 # switch.unit1_bedroom_switches_switch_2
 
   - platform: switch  
     name: Unit1 Kitchen Pendants
-    entity_id: switch.unit1_kitchen_pendants_switch
+    entity_id: switch.kitchen_pendants
 
   - platform: switch
     name: Unit1 Hallway Lights

--- a/packages/lights.yaml
+++ b/packages/lights.yaml
@@ -7,8 +7,8 @@
 group:
   interior_lights:
       - light.light_switch # light.kitchen_ceiling_light is what this should be, but I can't get it to name forcibly.
-      - light.unit1_light_livingroom_dimmer
-      - light.light_frontroom_ceiling_dimmer
+      - light.light_livingroom
+      - light.light_frontroom_ceiling
       - light.porch_light
       - light.kitchen_pendants
       - light.kitchen_cabinets
@@ -82,7 +82,7 @@ light:
       - light.unit1_light_livingroom_dimmer
       - light.light_frontroom_ceiling_dimmer
       - light.porch_light
-      - light.kitchen_pendants
+      - switch.kitchen_pendants
       - light.kitchen_cabinets
       - light.kitchen_ceiling_light
 
@@ -170,7 +170,7 @@ light:
 
   - platform: switch
     name: Unit1 Kitchen Ceiling Light
-    entity_id: switch.unit1_kitchen_ceiling_lights_switch
+    entity_id: switch.kitchen_ceiling_lights
   
   - platform: switch
     name: Person2 Nightlight
@@ -225,5 +225,9 @@ input_number:
   unit1_frontroom_lights_off_duration:
     icon: mdi:clock-start
     initial: 15
+    min: 1
+    max: 1440
+
+  room_light_level:
     min: 1
     max: 1440

--- a/packages/system/alarm.yaml
+++ b/packages/system/alarm.yaml
@@ -26,8 +26,8 @@ group:
     - binary_sensor.unit1_bathroom_window_door_state #sensor.unit1_bathroom_window_alarm_access_control
 
   all_house_locks:
-    - lock.frontdoor_lock
-    - lock.backdoor_lock
+    - lock.backdoor_lock_2
+    - lock.frontdoor
 
 input_boolean:
   panic_mode:

--- a/packages/system/sensors.yaml
+++ b/packages/system/sensors.yaml
@@ -27,8 +27,8 @@ sensor:
       check_dws_front_door_no_activity:
         entity_id: sensor.time
         value_template: >-
-          {% if states.sensor.unit1_frontdoor_alarm_access_control %}
-            {{ now().timestamp() - as_timestamp(state_attr('sensor.unit1_frontdoor_alarm_access_control', 'last_changed')) | int //60 > 780 }}
+          {% if states.binary_sensor.frontdoor_access_control_window_door_is_open %}
+            {{ now().timestamp() - as_timestamp(state_attr('binary_sensor.frontdoor_access_control_window_door_is_open', 'last_changed')) | int //60 > 780 }}
           {% else %}
             false
           {% endif %}
@@ -63,8 +63,8 @@ sensor:
       check_dws_unit2_back_door_no_activity:
         entity_id: sensor.time
         value_template: >-
-          {% if states.sensor.unit2_backdoor_alarm_access_control.last_changed %}
-            {{ now().timestamp() - as_timestamp(state_attr('sensor.unit2_backdoor_alarm_access_control', 'last_changed')) | int //60 > 780 }}
+          {% if states.binary_sensor.backdoor_access_control_window_door_is_open.last_changed %}
+            {{ now().timestamp() - as_timestamp(state_attr('binary_sensor.backdoor_access_control_window_door_is_open', 'last_changed')) | int //60 > 780 }}
           {% else %}
             false
           {% endif %}
@@ -81,8 +81,8 @@ sensor:
       check_dws_unit1_bathroom_window_no_activity:
         entity_id: sensor.time
         value_template: >-
-          {% if states.sensor.unit1_bathroom_window_alarm_access_control.last_changed %}
-            {{ now().timestamp() - as_timestamp(state_attr('sensor.unit1_bathroom_window_alarm_access_control', 'last_changed')) | int //60 > 780 }}
+          {% if states.binary_sensor.bathroom_window_access_control_window_door_is_open.last_changed %}
+            {{ now().timestamp() - as_timestamp(state_attr('binary_sensor.bathroom_window_access_control_window_door_is_open', 'last_changed')) | int //60 > 780 }}
           {% else %}
             false
           {% endif %}


### PR DESCRIPTION
Updated ZwaveJs to use the integration instead of MQTT. This PR renames a bunch of the entities to using more consistent naming conventions.