### PR TITLE
Added threshold before CPU alarm triggers

### DIFF
--- a/packages/system.yaml
+++ b/packages/system.yaml
@@ -276,6 +276,7 @@ automation:
       platform: numeric_state
       entity_id: sensor.processor_use
       above: 85
+      for: "00:01:00"
     action:
       - service: notify.admins
         data:


### PR DESCRIPTION
CPU alarm trigger is way too noisy, adding debounce by waiting for it to be above a threshold.