### PR TITLE
Moving MQTT Sensors to separate config

### DIFF
--- a/configuration/packages/system.yaml
+++ b/configuration/packages/system.yaml
@@ -122,23 +122,6 @@ automation:
       - service: counter.increment
         entity_id: counter.syslog_warnings
 
-sensor:
-  - platform: mqtt
-    name: MQTT Messages
-    state_topic: "$SYS/broker/load/messages/received"
-
-  - platform: mqtt
-    name: MQTT Clients
-    state_topic: "$SYS/broker/clients/total"
-
-  - platform: mqtt
-    name: MQTT Subscriber Count
-    state_topic: "$SYS/broker/subscriptions/count"
-
-  - platform: mqtt
-    name: MQTT Retained Message Count
-    state_topic: "$SYS/broker/retained messages/count"
-
 utility_meter:
   wan_in_monthly:
     source: sensor.internet_gb_downloaded

--- a/sensors/mqtt.yaml
+++ b/sensors/mqtt.yaml
@@ -1,0 +1,15 @@
+- platform: mqtt
+  name: MQTT Messages
+  state_topic: "$SYS/broker/messages/received"
+
+- platform: mqtt
+  name: MQTT Clients
+  state_topic: "$SYS/broker/clients/total"
+
+- platform: mqtt
+  name: MQTT Subscriber Count
+  state_topic: "$SYS/broker/subscriptions/count"
+
+- platform: mqtt
+  name: MQTT Retained Message Count
+  state_topic: "$SYS/broker/retained messages/count"


### PR DESCRIPTION
Reducing the ./packages dir, moving the mqtt sensors to their own specific config.